### PR TITLE
Make our binary role-based auth use a User's isAdmin attribute

### DIFF
--- a/erp-server/src/main/java/com/ttt/erp/config/SecurityConfig.java
+++ b/erp-server/src/main/java/com/ttt/erp/config/SecurityConfig.java
@@ -51,7 +51,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public void configAuthentication(AuthenticationManagerBuilder auth) throws Exception {
         auth.jdbcAuthentication().dataSource(dataSource)
                 .usersByUsernameQuery("select username, password, enabled from user_account where username=?")
-                .authoritiesByUsernameQuery("select username, role from user_roles where username=?")
+                .authoritiesByUsernameQuery(
+                    "select username, case when is_admin = 't' then 'ROLE_ADMIN' else 'ROLE_USER' end as role from user_account where username=?"
+                )
                 .passwordEncoder(passwordEncoder1());
     }
 


### PR DESCRIPTION
  - Modification to one line in SecurityConfig
  - Leaving the user_roles, user_roles_user_role_id_seq in the db to not break other local environments, but we'll no longer need those