### PR TITLE
Updated to show/hide nav links based on user auth & type

### DIFF
--- a/erp-client/package-lock.json
+++ b/erp-client/package-lock.json
@@ -346,8 +346,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -368,14 +367,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -390,20 +387,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -520,8 +514,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -533,7 +526,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -548,7 +540,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -556,14 +547,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -582,7 +571,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -663,8 +651,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -676,7 +663,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -762,8 +748,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -799,7 +784,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -819,7 +803,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -863,14 +846,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -5989,8 +5970,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6011,14 +5991,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6033,20 +6011,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6163,8 +6138,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6176,7 +6150,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6191,7 +6164,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -6199,14 +6171,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6225,7 +6195,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -6306,8 +6275,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -6319,7 +6287,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -6405,8 +6372,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -6442,7 +6408,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6462,7 +6427,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -6506,14 +6470,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -10713,8 +10675,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10735,14 +10696,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10757,20 +10716,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10887,8 +10843,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10900,7 +10855,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10915,7 +10869,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -10923,14 +10876,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10949,7 +10900,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -11030,8 +10980,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11043,7 +10992,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11129,8 +11077,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11166,7 +11113,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11186,7 +11132,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11230,14 +11175,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11543,8 +11486,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -11565,14 +11507,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11587,20 +11527,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11717,8 +11654,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11730,7 +11666,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11745,7 +11680,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -11753,14 +11687,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11779,7 +11711,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -11860,8 +11791,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11873,7 +11803,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11959,8 +11888,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11996,7 +11924,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -12016,7 +11943,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -12060,14 +11986,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/erp-client/src/app/app.component.html
+++ b/erp-client/src/app/app.component.html
@@ -5,15 +5,14 @@
         <img [src]="'assets/Images/prototype-logo.svg'" class="logo">
       </a>
     </div>
-    <!-- <span class="menu-spacer"></span> -->
 
     <ul class="menu-links">
-      <li><a mat-button href="/awards">Awards</a></li>
-      <li><a mat-button href="/admin">Admin</a></li>
-      <li><a mat-button href="/reports">Reports</a></li>
-      <li><a mat-button href="/">Employees</a></li>
-      <li><a mat-button href="/account">Account</a></li>
-      <li><a mat-button (click)="handleLogout()">Logout</a></li>
+      <li *ngIf="isLoggedIn"><a mat-button href="/awards">Awards</a></li>
+      <li *ngIf="isLoggedIn && isAdmin"><a mat-button href="/admin">Admin</a></li>
+      <li *ngIf="isLoggedIn"><a mat-button href="/reports">Reports</a></li>
+      <li *ngIf="isLoggedIn"><a mat-button href="/account">Account</a></li>
+      <li *ngIf="isLoggedIn"><a mat-button (click)="handleLogout()">Logout</a></li>
+      <li *ngIf="!isLoggedIn"><a mat-button href="/login">Login</a></li>
     </ul>
   </mat-toolbar-row>
 </mat-toolbar>

--- a/erp-client/src/app/app.component.html
+++ b/erp-client/src/app/app.component.html
@@ -9,7 +9,7 @@
     <ul class="menu-links">
       <li *ngIf="isLoggedIn"><a mat-button href="/awards">Awards</a></li>
       <li *ngIf="isLoggedIn && isAdmin"><a mat-button href="/admin">Admin</a></li>
-      <li *ngIf="isLoggedIn"><a mat-button href="/reports">Reports</a></li>
+      <li *ngIf="isLoggedIn && isAdmin"><a mat-button href="/reports">Reports</a></li>
       <li *ngIf="isLoggedIn"><a mat-button href="/account">Account</a></li>
       <li *ngIf="isLoggedIn"><a mat-button (click)="handleLogout()">Logout</a></li>
       <li *ngIf="!isLoggedIn"><a mat-button href="/login">Login</a></li>

--- a/erp-client/src/app/app.component.ts
+++ b/erp-client/src/app/app.component.ts
@@ -1,6 +1,8 @@
-import {Component} from '@angular/core';
-import {AuthenticationService} from './services/authentication/authentication.service';
-import {Router} from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { AuthenticationService } from './services/authentication/authentication.service';
+import { Router } from '@angular/router';
+import { CookieService } from 'ngx-cookie-service';
+
 
 @Component({
   selector: 'erp-root',
@@ -9,13 +11,37 @@ import {Router} from '@angular/router';
 })
 export class AppComponent {
   title = 'employee-recognition-portal';
+  _isLoggedIn: boolean = false;
+  _isAdmin: boolean = false;
 
   constructor (
-    private authService: AuthenticationService,
-    private router: Router
+    private _authService: AuthenticationService,
+    private _router: Router,
+    private _cookieService: CookieService,
   ) {}
 
+  ngOnInit(): void {
+    this.refreshLoginState();
+  }
+
+  get isLoggedIn() {
+    return this._isLoggedIn;
+  }
+
+  get isAdmin() {
+    return this._isAdmin;
+  }
+
   handleLogout(): void {
-    this.authService.logout();
+    this._authService.logout();
+    this.refreshLoginState()
+  }
+
+  refreshLoginState(): void {
+    console.log('refreshing login state');
+    const cookies = this._cookieService.getAll();
+    this._isLoggedIn = cookies['userId'] !== null && cookies['userId'] !== undefined;
+    this._isAdmin = this.isLoggedIn && cookies['admin'] == 'true';
+    console.log('isLoggedIn: ', this.isLoggedIn, ' | isAdmin: ', this._isAdmin);
   }
 }

--- a/erp-client/src/app/app.component.ts
+++ b/erp-client/src/app/app.component.ts
@@ -38,10 +38,8 @@ export class AppComponent {
   }
 
   refreshLoginState(): void {
-    console.log('refreshing login state');
     const cookies = this._cookieService.getAll();
     this._isLoggedIn = cookies['userId'] !== null && cookies['userId'] !== undefined;
     this._isAdmin = this.isLoggedIn && cookies['admin'] == 'true';
-    console.log('isLoggedIn: ', this.isLoggedIn, ' | isAdmin: ', this._isAdmin);
   }
 }

--- a/erp-client/src/app/components/admin/admin-home/admin-home.component.ts
+++ b/erp-client/src/app/components/admin/admin-home/admin-home.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { AppComponent } from 'src/app/app.component';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'erp-admin-home',
@@ -7,11 +9,14 @@ import { Component, OnInit } from '@angular/core';
 })
 export class AdminHomeComponent implements OnInit {
 
-  constructor() { }
+  constructor(
+    private _app: AppComponent,
+    private _router: Router,
+  ) {}
 
   ngOnInit() {
+    if (!this._app.isAdmin) {
+      this._router.navigate(['/']);
+    }
   }
-
-
-
 }

--- a/erp-client/src/app/components/home/home.component.ts
+++ b/erp-client/src/app/components/home/home.component.ts
@@ -1,6 +1,6 @@
-import {Component, OnInit} from '@angular/core';
-import {EmployeeService} from '../../services/employee/employee.service';
-import {Employee} from '../../models/employee.model';
+import { Component, OnInit } from '@angular/core';
+import { AppComponent } from 'src/app/app.component';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'erp-home',
@@ -8,45 +8,21 @@ import {Employee} from '../../models/employee.model';
   styleUrls: ['./home.component.scss']
 })
 export class HomeComponent implements OnInit {
-
-  awards: Employee[] = [];
-  employees: Employee[] = null;
-  employee: Employee;
-  errorMessage: string;
-  employeeId: number;
-  id: number;
-
-  constructor(private employeeService: EmployeeService) { }
-
+  constructor(
+    private _app: AppComponent,
+    private _router: Router,
+  ) {}
+  
   ngOnInit() {
-  }
-
-  getAllEmployees(): void {
-    this.employeeService.getAllEmployees().subscribe(
-      (employees) => {
-        this.employees = employees;
-      },
-      (error) => {
-        this.errorMessage = 'Failed to load employees';
-      },
-      () => {
-        // If you want to do something
-      }
-    );
-  }
-
-  getEmployeeById(id: number): void {
-    this.employee = null;
-    this.employeeService.getEmployeeById(id).subscribe(
-      (employee) => {
-        this.employee = employee;
-      },
-      (error) => {
-        this.errorMessage = 'Failed to load employee';
-      },
-      () => {
-        // If you want to do something
-      }
-    );
+    // if not logged in, redirect to login page.
+    if (!this._app.isLoggedIn) {
+      this._router.navigate(['/login']);
+    // if admin, redirect to admin page.
+    } else if (this._app.isAdmin) {
+      this._router.navigate(['/admin']);
+    // if logged in but not admin, redirect to account page.
+    } else {
+      this._router.navigate(['/account']);
+    }
   }
 }

--- a/erp-client/src/app/components/login/login.component.html
+++ b/erp-client/src/app/components/login/login.component.html
@@ -1,9 +1,3 @@
-<!--<input [(ngModel)]="username" placeholder="Username">{{username}}-->
-<!--<br>-->
-<!--<input [(ngModel)]="password" placeholder="Password">{{password}}-->
-<!--<br>-->
-<!--<button (click)="handleLogin()" [disabled]="!username || !password">Click me!</button>-->
-
 <div class="login-container">
   <mat-card class="login-card">
     <mat-card-header>
@@ -12,7 +6,7 @@
       </div>
     </mat-card-header>
     <mat-card-content>
-      <form>
+      <form (submit)="handleLogin()">
         <table cellspacing="0">
           <tr>
             <td>
@@ -22,16 +16,21 @@
             </td>
           </tr>
           <tr>
-            <td><mat-form-field class="password-input">
-              <input matInput placeholder="Password" [(ngModel)]="password"type="password" name="password" required>
-            </mat-form-field></td>
-          </tr></table>
+            <td>
+              <mat-form-field class="password-input">
+                <input matInput placeholder="Password" [(ngModel)]="password"type="password" name="password" required>
+              </mat-form-field>
+            </td>
+          </tr>
+        </table>
+
+          <a mat-label class="forgot-password" href="/forgotPassword">Forgot Password?</a>
+          <mat-spinner [style.display]="showSpinner ? 'block' : 'none'"></mat-spinner>
+
+          <mat-card-actions>
+            <button type="submit" mat-raised-button (click)="handleLogin()" color="primary" class="login-button">Login</button>
+          </mat-card-actions>
       </form>
-      <a mat-label class="forgot-password" href="/forgotPassword">Forgot Password?</a>
-      <mat-spinner [style.display]="showSpinner ? 'block' : 'none'"></mat-spinner>
     </mat-card-content>
-    <mat-card-actions>
-      <button mat-raised-button (click)="handleLogin()" color="primary" class="login-button">Login</button>
-    </mat-card-actions>
   </mat-card>
 </div>

--- a/erp-client/src/app/components/login/login.component.scss
+++ b/erp-client/src/app/components/login/login.component.scss
@@ -2,11 +2,22 @@ mat-spinner {
   margin: auto;
 }
 
-.login-container {
-  height: 55vh;
+.login-container,
+.login-card,
+.mat-card-header {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+.login-container {
+  min-height: 400px;
+  margin: 40px auto 0 auto;
+}
+
+.login-card {
+  width: 200px;
 }
 
 .login-logo {
@@ -26,6 +37,20 @@ mat-spinner {
   font-size: 10px;
 }
 
-.login-button {
-  justify-content: center;
+table {
+  margin-bottom: 1em;
 }
+
+mat-card-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 1em;
+  padding: 0 4px;
+}
+
+.login-button {
+  flex: 1;
+  margin-top: 1em;
+  min-width: 100px;
+}
+

--- a/erp-client/src/app/components/login/login.component.ts
+++ b/erp-client/src/app/components/login/login.component.ts
@@ -1,52 +1,39 @@
-import {Component, OnInit} from '@angular/core';
-import {AuthenticationService} from '../../services/authentication/authentication.service';
-import {Router} from '@angular/router';
-import {FormBuilder, FormGroup, Validators} from '@angular/forms';
-import { CookieService } from 'ngx-cookie-service';
+import { Component } from '@angular/core';
+import { AuthenticationService } from '../../services/authentication/authentication.service';
+import { Router } from '@angular/router';
+import { AppComponent } from 'src/app/app.component';
 
 @Component({
   selector: 'erp-login',
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']
 })
-export class LoginComponent implements OnInit {
-
-  // loginForm: FormGroup;
+export class LoginComponent {
   username: string;
   password: string;
   errorMessage: string;
   showSpinner = false;
 
-  constructor(private authService: AuthenticationService,
-              private router: Router,
-              private cookieService: CookieService){ }
+  constructor(
+    private authService: AuthenticationService,
+    private router: Router,
+    private app: AppComponent
+  ) {}
 
-  // constructor(private loginService: LoginService) {}
-
-  ngOnInit() {
-    // this.loginForm = this.formBuilder.group({
-    //   username: ['', Validators.required],
-    //   password: ['', Validators.required]
-    // });
-  }
 
   handleLogin(): void {
     this.showSpinner = true;
-    this.authService.authenticate({username: this.username, password: this.password}).subscribe((user) => {
-        // should add a way to redirect admin to dashboard and user to home page
-      if (this.cookieService.get('admin') == 'true') {
-        this.router.navigate(['/admin']);
-      } else {
-        this.router.navigate(['/awards']);
-      }
-        this.showSpinner = false;
-      },
-      (error) => {
-        this.errorMessage = error;
-        this.showSpinner = false;
-      },
-      () => {
-        this.showSpinner = false;
-      });
+    this.authService.authenticate({
+      username: this.username, 
+      password: this.password
+    }).subscribe(() => {
+      this.app.refreshLoginState();
+      this.router.navigate(['/']);
+    },
+    (error) => {
+      this.errorMessage = error;
+    });
+
+    this.showSpinner = false;
   }
 }

--- a/erp-client/src/app/components/report/report.component.ts
+++ b/erp-client/src/app/components/report/report.component.ts
@@ -1,17 +1,11 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { CookieService } from 'ngx-cookie-service';
-import { MatTableDataSource, MatPaginator, MatSort } from '@angular/material';
-import { concat, of, throwError, forkJoin, Observable } from 'rxjs';
-import { concatAll } from 'rxjs/operators';
+import { MatTableDataSource, MatSort } from '@angular/material';
+import { Router } from '@angular/router';
 
 import { ReportService } from 'src/app/services/report/report.service';
-import { AwardTypeService } from 'src/app/services/awardType/awardType.service';
 import { SnackbarService } from 'src/app/services/snackbar/snackbar.service';
-import { User } from 'src/app/models/user.model';
-import { AwardType } from 'src/app/models/awardType.model';
-import { Employee } from 'src/app/models/employee.model';
-import { ValidateDate } from 'src/app/validators/date.validator';
-import { ValidateTime } from 'src/app/validators/time.validator';
+import { AppComponent } from 'src/app/app.component';
 
 
 @Component({
@@ -21,13 +15,6 @@ import { ValidateTime } from 'src/app/validators/time.validator';
 })
 export class ReportComponent implements OnInit {
   @ViewChild(MatSort, { static: false }) sort: MatSort;
-
-  //
-  // cookies
-  //
-  cookieUser: string;
-  isAdmin: boolean;
-  userId: number;
 
   //
   // report data
@@ -104,25 +91,21 @@ export class ReportComponent implements OnInit {
 
 
   constructor(
-    private _cookieService: CookieService,
+    private _app: AppComponent,
     private _reportService: ReportService,
     private _snackbar: SnackbarService,
+    private _router: Router,
   ) { 
-    // check user credentials
-    const cookies: {} = _cookieService.getAll();
-    this.cookieUser = cookies['user'];
-    this.isAdmin = cookies['admin'] == 'true';
-    this.userId = cookies['userId'] || 0;
 
     Object.assign(this.regionAwardTotalsChart, this.regionAwardCounts);
   }
 
   ngOnInit() {
+    if (!this._app.isAdmin) {
+      this._router.navigate(['/']);
+    }
+
     this.getRegionAwardCounts();
-    // this.getUserAwardCounts();
-    // this.getAwardTypeCounts();
-    // this.getEmployeeAwardCounts();
-    // this.getEmployeeAwardDiversity();
     this.regionAwardTotalsChart['data'] = [...this.regionAwardTotalsChart['data']];
   }
 

--- a/erp-client/src/app/services/employee/employee.service.ts
+++ b/erp-client/src/app/services/employee/employee.service.ts
@@ -8,8 +8,7 @@ import {Employee} from '../../models/employee.model';
 })
 
 export class EmployeeService {
-  constructor(private httpClient: HttpClient) {
-  }
+  constructor(private httpClient: HttpClient) {}
 
   getEmployeeById(id: number): Observable<Employee> {
     return this.httpClient.get<Employee>(`/api/employees/${id}`);
@@ -18,8 +17,4 @@ export class EmployeeService {
   getAllEmployees(): Observable<Employee[]> {
     return this.httpClient.get<Employee[]>(`/api/employees`);
   }
-
-  // getAllAwards(): Observable<Employee[]> {
-  //   return this.httpClient.get<Employee[]>(`/api/awards`);
-  // }
 }


### PR DESCRIPTION
1) Dynamically hides/shows navigation links based on:
- whether or not the user is logged in, and
  - if not logged in, only the 'login' link is shown.
- whether or not a logged in user is admin or not
  - if admin, all links are visible (wasn't sure if 'Account' page should be visible for admins, so I left it in for now. would be an easy fix if it shouldn't be visible for admins.
  - if not admin, the 'Admin' and 'Reports' links are not visible.
2) Updates the Login form to submit when the user presses the Enter key.

3) Removes the link to the `/Employees` page, and changes a little bit of the login in the `/` page to update the visible nav links. 