### PR TITLE
Small fix to redirect non-admin user to /awards instead of /account

### DIFF
--- a/erp-client/src/app/components/home/home.component.ts
+++ b/erp-client/src/app/components/home/home.component.ts
@@ -22,7 +22,7 @@ export class HomeComponent implements OnInit {
       this._router.navigate(['/admin']);
     // if logged in but not admin, redirect to account page.
     } else {
-      this._router.navigate(['/account']);
+      this._router.navigate(['/awards']);
     }
   }
 }


### PR DESCRIPTION
Apologies for the small merges --- This just fixes a small error from one of my previous merges that was redirecting the non-admin user to the `/account` page after login (which was not what we'd talked about). This change now redirects the non-admin user to the `/awards` page after login.