### PR TITLE
Create custom annotations to tell LogService to ignore field

### DIFF
--- a/erp-server/src/main/java/com/ttt/erp/annotation/Relationship.java
+++ b/erp-server/src/main/java/com/ttt/erp/annotation/Relationship.java
@@ -1,0 +1,8 @@
+package com.ttt.erp.annotation;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)  
+@Target(ElementType.FIELD)
+public @interface Relationship {
+
+}

--- a/erp-server/src/main/java/com/ttt/erp/model/UserAccount.java
+++ b/erp-server/src/main/java/com/ttt/erp/model/UserAccount.java
@@ -2,6 +2,7 @@ package com.ttt.erp.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ttt.erp.annotation.Relationship;
 
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.GrantedAuthority;
@@ -62,14 +63,17 @@ public class UserAccount {
     // relationships
     @OneToMany(targetEntity = Award.class, mappedBy = "userAccount", cascade = CascadeType.ALL)
     @JsonIgnore
+    @Relationship
     private Set<Award> awards = new HashSet<>();
 
     @OneToMany(targetEntity = RecoveryQuestion.class, mappedBy = "userAccount", cascade = CascadeType.ALL)
     @JsonIgnore
+    @Relationship
     private Set<RecoveryQuestion> questions = new HashSet<>();
 
     @OneToMany(targetEntity = Log.class, mappedBy = "userAccount", cascade = CascadeType.ALL)
     @JsonIgnore
+    @Relationship
     private Set<Log> logs = new HashSet<>();
 
 

--- a/erp-server/src/main/java/com/ttt/erp/service/LogService.java
+++ b/erp-server/src/main/java/com/ttt/erp/service/LogService.java
@@ -1,12 +1,16 @@
 package com.ttt.erp.service;
 
-import org.springframework.stereotype.Service;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import com.ttt.erp.annotation.Relationship;
 import com.ttt.erp.model.Log;
 import com.ttt.erp.repository.LogRepository;
 import com.ttt.erp.repository.UserAccountRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
+import org.springframework.stereotype.Service;
 
 /*
 * TR: This is meant to be extended by other service classes that should get logged.
@@ -37,6 +41,21 @@ public class LogService {
     public String getEnd() { return this.end; }
   }
 
+  private String ignoreAnnotationName = "Relationship";
+
+  boolean hasAnnotationByName(Field field, String annotationName) {
+    Annotation[] annotations = field.getAnnotations();
+    if (annotations.length > 0){
+      for (int i=0; i<annotations.length; i++) {
+        System.out.println(annotations[i].annotationType().getSimpleName());
+        if (annotations[i].annotationType().getSimpleName().equals(annotationName)) {
+          return true;
+        } 
+      }
+    }
+    return false;
+  }
+
   /* This returns a list of differing property names between 2 objects. Uses Java reflections
   * which are pretty cool. Check out some stuff on Java reflections here: 
   * https://stackoverflow.com/questions/10638826/java-reflection-impact-of-setaccessibletrue
@@ -49,14 +68,14 @@ public class LogService {
       for (int i = 0; i < startFields.length; i++) {
         startFields[i].setAccessible(true);
         endFields[i].setAccessible(true);
-
-        String strStart = startFields[i].get(start) != null ? startFields[i].get(start).toString() : "";
-        String strEnd = startFields[i].get(end) != null ? startFields[i].get(end).toString() : "";
-
-        if (!strStart.equals(strEnd)) {
-          diffs.add (
-            new PropertyChange(startFields[i].getName(), strStart, strEnd)
-          );
+        if (!hasAnnotationByName(startFields[i], ignoreAnnotationName) && !hasAnnotationByName(endFields[i], ignoreAnnotationName)) {
+          String strStart = startFields[i].get(start) != null ? startFields[i].get(start).toString() : "";
+          String strEnd = startFields[i].get(end) != null ? startFields[i].get(end).toString() : "";
+          if (!strStart.equals(strEnd)) {
+            diffs.add (
+              new PropertyChange(startFields[i].getName(), strStart, strEnd)
+            );
+          }
         }
       }
     } catch (Exception e) {


### PR DESCRIPTION
  - For a relationship field, add the @Relationship annotation
  - In the log service, ignore reflected object fields that have the @Relationship annotation
  - When used properly, ensures only the object's intended fields are inspected