### PR TITLE
Add recovery questions to admin controls

### DIFF
--- a/db/user_roles.txt
+++ b/db/user_roles.txt
@@ -1,0 +1,10 @@
+    Column    |          Type          | Collation | Nullable |                     Default                      | Storage  | Stats target | Description
+--------------+------------------------+-----------+----------+--------------------------------------------------+----------+--------------+-------------
+ user_role_id | integer                |           | not null | nextval('user_roles_user_role_id_seq'::regclass) | plain    |              |
+ username     | character varying(255) |           | not null |                                                  | extended |              |
+ role         | character varying(20)  |           | not null |                                                  | extended |              |
+Indexes:
+    "user_roles_pkey" PRIMARY KEY, btree (user_role_id)
+    "user_roles_username_role_key" UNIQUE CONSTRAINT, btree (username, role)
+Foreign-key constraints:
+    "user_roles_username_fkey" FOREIGN KEY (username) REFERENCES user_account(username)

--- a/erp-client/src/app/components/admin/admin-controls/admin-controls.component.html
+++ b/erp-client/src/app/components/admin/admin-controls/admin-controls.component.html
@@ -1,21 +1,21 @@
 <div id="controls-wrapper">
   <h1 class="mat-h1">User Controls</h1>
+  <p class="mat-subheading-1">Admin users can create, update, or delete users.</p>
   <div id="controls">
 
-    <mat-tab-group mat-align-tabs="center">
+    <mat-tab-group>
 
       <mat-tab label="New">
         <form [formGroup]="newUserForm" (ngSubmit)="submitNewUser()">
           <mat-checkbox 
-            class="admin-check" 
-
+            class="admin-check"
             formControlName="isAdmin"
           >Admin user</mat-checkbox>
-          <mat-form-field>
-            <input matInput type="text" placeholder="Username" formControlName="username" required>
+          <mat-form-field class="col-half" >
+            <input matInput type="text" placeholder="Username" formControlName="username"required>
             <mat-error *ngIf="newUserForm.controls.username.hasError('required')">Username is required</mat-error>
           </mat-form-field>
-          <mat-form-field>
+          <mat-form-field class="col-half" >
             <input matInput type="text" placeholder="Password" formControlName="password" required>
             <mat-error *ngIf="newUserForm.controls.password.hasError('required')">Password is required</mat-error>
           </mat-form-field>
@@ -24,13 +24,27 @@
             <mat-error *ngIf="newUserForm.controls.email.hasError('required')">Email is required</mat-error>
             <mat-error *ngIf="newUserForm.controls.email.hasError('email')">Invalid email</mat-error>
           </mat-form-field>
+          <div formGroupName="questions">
+            <mat-form-field class="col-half">
+              <input matInput type="text" placeholder="Hometown" formControlName="answer1" required>
+              <mat-error *ngIf="newUserForm.get('questions.answer1').hasError('required')">Answer is required</mat-error>
+            </mat-form-field>
+            <mat-form-field class="col-half">
+              <input matInput type="text" placeholder="First pet name" formControlName="answer2" required>
+              <mat-error *ngIf="newUserForm.get('questions.answer2').hasError('required')">Answer is required</mat-error>
+            </mat-form-field>
+            <mat-form-field>
+              <input matInput type="text" placeholder="First car" formControlName="answer3" required>
+              <mat-error *ngIf="newUserForm.get('questions.answer3').hasError('required')">Answer is required</mat-error>
+            </mat-form-field>
+          </div>
           <erp-canvas [hidden]="newUserForm.value.isAdmin" [width]="300" [height]="150" [includeExportButton]="false"></erp-canvas>
           <div class="common-buttons">
             <button
               mat-button 
               color="primary" 
               class="action-button-left" 
-              [disabled]="newUserForm.invalid || (!_newAdminCheck && !canvasChild.touched)" 
+              [disabled]="newUserForm.invalid || (!newUserForm.value.isAdmin && !canvasChild.touched)" 
               type="submit">
             Submit</button>
             <button mat-button color="accent" class="action-button-right" (click)="resetForm(newUserForm)" type="reset">Clear</button>
@@ -43,7 +57,7 @@
           <mat-form-field>
             <mat-label>User</mat-label>
             <mat-select (selectionChange)="onSelect($event.value)" required>
-              <mat-option> - </mat-option>
+              <mat-option [value]="null"> - </mat-option>
               <mat-option *ngFor="let user of _users" [value]="user.id" >{{user.username}}</mat-option>
             </mat-select>
           </mat-form-field>

--- a/erp-client/src/app/components/admin/admin-controls/admin-controls.component.scss
+++ b/erp-client/src/app/components/admin/admin-controls/admin-controls.component.scss
@@ -1,8 +1,11 @@
+@import '../../../../styles.scss';
+
 #controls-wrapper {
-  float: left;
-  margin-left: 5%;
+  margin: auto;
+  margin-top: 5%;
+  margin-bottom: 5%;
   height: 50%;
-  width: 30%;
+  width: 75%;
 }
 
 #controls {
@@ -18,13 +21,8 @@
   margin-bottom: 10px;
 }
 
-h1 {
-  padding-top: 10px;
-  height: 60px;
-  margin-bottom: 0;
-}
-
 form {
+  margin: auto;
   margin-top: 15px;
 }
 
@@ -32,14 +30,22 @@ form {
   width: 80px !important;
 }
 
-.mat-form-field {
+mat-form-field.mat-form-field {
   display: block;
-  width: 80%;
+  width: 90%;
   margin: auto;
 }
 
+mat-form-field.col-half, div.col-half {
+  display: inline-block;
+  width: 40%;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+
 .admin-check.mat-checkbox {
-  margin-left: 10%;
+  display: block;
+  margin-left: 5%;
   margin-bottom: 2%;
 }
 

--- a/erp-client/src/app/components/admin/admin-home/admin-home.component.html
+++ b/erp-client/src/app/components/admin/admin-home/admin-home.component.html
@@ -1,5 +1,7 @@
 <mat-toolbar>
   <span>Admin Home</span>
 </mat-toolbar>
-<admin-controls></admin-controls>
-<admin-table></admin-table>
+<div class="controls">
+  <admin-controls></admin-controls>
+</div>
+<!--<admin-table></admin-table>-->

--- a/erp-client/src/app/components/admin/admin-home/admin-home.component.scss
+++ b/erp-client/src/app/components/admin/admin-home/admin-home.component.scss
@@ -1,3 +1,7 @@
 h1 {
   margin-top: 5%;
 }
+
+.controls {
+  padding-bottom: 5%;
+}

--- a/erp-client/src/app/components/admin/admin-table/admin-table.component.scss
+++ b/erp-client/src/app/components/admin/admin-table/admin-table.component.scss
@@ -1,8 +1,7 @@
 #admin-datatable {
-  float: left;
-  margin-left: 5%;
-  margin-right: auto;
-  width: 55%;
+  margin: auto;
+  height: 50%;
+  width: 40%;
 }
 
 #pre-table-header {

--- a/erp-client/src/app/components/createAccount/set-recovery-questions/set-recovery-questions.component.ts
+++ b/erp-client/src/app/components/createAccount/set-recovery-questions/set-recovery-questions.component.ts
@@ -1,5 +1,6 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {RecoveryQuestion} from '../../../models/recovery.model';
+import { zip } from 'rxjs';
 
 @Component({
   selector: 'erp-set-recovery-questions',
@@ -13,10 +14,12 @@ export class SetRecoveryQuestionsComponent implements OnInit {
   question1 = 'What is your hometown?';
   question2 = 'What was your first pets name?';
   question3 = 'What was your first car?';
+  questions: string[] = [this.question1, this.question2, this.question3];
 
   answer1: string;
   answer2: string;
   answer3: string;
+  answers: string[] = [this.answer1, this.answer2, this.answer3];
 
   constructor() { }
 
@@ -29,5 +32,17 @@ export class SetRecoveryQuestionsComponent implements OnInit {
       {id: null, question: this.question2, answer: this.answer2},
       {id: null, question: this.question3, answer: this.answer3}
     ]);
+  }
+
+  mapRecoveryQuestionsToAnswers(questions: string[], answers: string[]): RecoveryQuestion[] {
+    let recoveryQuestions: RecoveryQuestion[] = [];
+    questions.forEach( (q, index) => {
+      let rq = new RecoveryQuestion();
+      rq.id = index + 1;
+      rq.question = q;
+      rq.answer = answers[index];
+      recoveryQuestions.push(rq);
+    })
+    return recoveryQuestions;
   }
 }

--- a/erp-client/src/app/components/my-page/my-page.component.ts
+++ b/erp-client/src/app/components/my-page/my-page.component.ts
@@ -6,6 +6,7 @@ import {User} from 'src/app/models/user.model';
 import {SnackbarService} from 'src/app/services/snackbar/snackbar.service';
 import {FormGroup} from '@angular/forms';
 import {MatInput} from '@angular/material';
+import { AccountRecoveryService } from 'src/app/services/account-recovery/account-recovery.service';
 
 @Component({
   selector: 'erp-my-page',
@@ -21,10 +22,11 @@ export class MyPageComponent extends AdminControlsComponent implements OnInit {
 
   constructor(
     private cookieService: CookieService,
-    private snackbarService: SnackbarService,
-    public userService: UserService
+    public _snackbar: SnackbarService,
+    public userService: UserService,
+    public accountRecoveryService: AccountRecoveryService
   ) {
-    super(userService);
+    super(userService, accountRecoveryService, _snackbar);
     this.currentUser = cookieService.get('user');
     this.readOnly = true;
     this.passwordType = 'password';
@@ -61,7 +63,7 @@ export class MyPageComponent extends AdminControlsComponent implements OnInit {
         this.accountForm = this.initFormGroupFromUser(this.me);
       },
       error => {
-        this.onError(`Unable to get current user: ${error})`);
+        this.customErrorSnackbar(`Unable to get current user: ${error})`);
       }
     );
   }
@@ -69,17 +71,14 @@ export class MyPageComponent extends AdminControlsComponent implements OnInit {
   updateMyUser() {
     this.userService.updateUser(this.accountForm.value).subscribe(
       (user) => {
+        this.customSuccessSnackbar(`Updated user, ${user.username}!`);
         this.me = user;
         this.toggleReadOnly();
       },
       (error) => {
-        this.onError(`Failed to updated user: ${error}`);
+        this.customErrorSnackbar(`Failed to updated user: ${error}`);
       }
     );
-  }
-
-  onError(message: string) {
-    this.snackbarService.showError(message, 'Dang it', {duration: null, panelClass: [ 'snackbar-error' ]})
   }
 
 }

--- a/erp-client/src/app/models/user.model.ts
+++ b/erp-client/src/app/models/user.model.ts
@@ -1,3 +1,5 @@
+import { RecoveryQuestion } from './recovery.model';
+
 export class User {
   id: number;
   email: string;
@@ -6,4 +8,8 @@ export class User {
   signature: string;
   isAdmin: boolean;
   isEnabled: boolean;
+}
+
+export class UserWithRecoveryQuestions extends User {
+  questions: RecoveryQuestion[]
 }

--- a/erp-server/src/main/java/com/ttt/erp/controller/UserAccountController.java
+++ b/erp-server/src/main/java/com/ttt/erp/controller/UserAccountController.java
@@ -1,5 +1,6 @@
 package com.ttt.erp.controller;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.ttt.erp.model.Award;
 import com.ttt.erp.model.UserAccount;
 import com.ttt.erp.repository.AwardRepository;
@@ -61,10 +62,14 @@ public class UserAccountController {
     }
 
     @PostMapping
-    public Optional<UserAccount> addUserAccount (@RequestBody UserAccount newUserAccount, Principal principal) {
-        UserAccount actingUser = this.repository.findByUsername(principal.getName());
-        return this.service.createUser(actingUser.getId(), newUserAccount);
-        //return Optional.empty();
+    public ResponseEntity<UserAccount> addUserAccount (
+        @RequestBody UserAccount newUserAccount, 
+        @CookieValue(value = "user") String actingUserName
+    ) {
+        UserAccount actingUser = this.repository.findByUsername(actingUserName);
+        Optional<UserAccount> result = this.service.createUser(actingUser.getId(), newUserAccount);
+        Boolean success = result.isPresent();
+        return success ? ResponseEntity.ok().body(result.get()) : ResponseEntity.badRequest().body(null);
     }
 
     // callback for checking login status
@@ -75,19 +80,24 @@ public class UserAccountController {
 
 
     @PutMapping("/{id}")
-    public Optional<UserAccount> updateUserAccountById (
+    public ResponseEntity<UserAccount> updateUserAccountById (
         @CookieValue(value = "user") String actingUser,
         @PathVariable("id") Long userId,
-        @RequestBody UserAccount modified) {
-        return this.service.updateUser(this.repository.findByUsername(actingUser).getId(), userId, modified);
+        @RequestBody UserAccount modified
+    ) {
+        Optional<UserAccount> result = this.service.updateUser(this.repository.findByUsername(actingUser).getId(), userId, modified);
+        Boolean success = result.isPresent();
+        return success ? ResponseEntity.ok().body(result.get()) : ResponseEntity.badRequest().body(null);
     }
 
     @DeleteMapping("/{id}")
-    public Optional<UserAccount> deleteUserAccountById (
+    public ResponseEntity<UserAccount> deleteUserAccountById (
         @CookieValue(value = "user") String actingUser,
         @PathVariable("id") Long userId
     ) {
-        return this.service.deleteUser(this.repository.findByUsername(actingUser).getId(), userId);
+        Optional<UserAccount> result = this.service.deleteUser(this.repository.findByUsername(actingUser).getId(), userId);
+        Boolean success = result.isPresent();
+        return success ? ResponseEntity.ok().body(result.get()) : ResponseEntity.badRequest().body(null);
     }
 
     @GetMapping

--- a/erp-server/src/main/java/com/ttt/erp/model/UserAccount.java
+++ b/erp-server/src/main/java/com/ttt/erp/model/UserAccount.java
@@ -82,15 +82,6 @@ public class UserAccount implements Serializable {
 
     public UserAccount() {}
 
-    public UserAccount(Long id, String email, String username, String password, String signature, Boolean isAdmin) {
-        this.id = id;
-        this.email = email;
-        this.username = username;
-        this.password = password;
-        this.signature = signature;
-        this.isAdmin = isAdmin;
-    }
-
     public UserAccount(Long id, String email, String username, String password, String signature, Boolean isAdmin, Boolean isEnabled, Set<Award> awards, Set<RecoveryQuestion> questions, Set<Log> logs) {
         this.id = id;
         this.email = email;
@@ -112,6 +103,15 @@ public class UserAccount implements Serializable {
         this.signature = signature;
         this.isAdmin = isAdmin;
         this.isEnabled = isEnabled;
+    }
+
+    public UserAccount(Long id, String email, String username, String password, String signature, Boolean isAdmin) {
+        this.id = id;
+        this.email = email;
+        this.username = username;
+        this.password = password;
+        this.signature = signature;
+        this.isAdmin = isAdmin;
     }
 
     public UserAccount(String email, String username, String password, Boolean isAdmin) {

--- a/erp-server/src/main/java/com/ttt/erp/service/RecoveryService.java
+++ b/erp-server/src/main/java/com/ttt/erp/service/RecoveryService.java
@@ -69,6 +69,7 @@ public class RecoveryService extends LogService{
             return false;
         }
     }
+
     public Boolean setRecoveryQuestions(String username, List<RecoveryQuestion> questions) {
         try {
             UserAccount userAccount = this.userAccountRepository.findByUsername(username);


### PR DESCRIPTION
  - Also remove the employee table that doesn't provide any value on the admin page
  - Also build ResponseEntities
  - Also make snackbars. For all crud operations on this form and for the user update on account page.
  - Also change some styling on the admin controls form

Note: Uses a separate request for the recovery question setting... not super thrilled about that but it works. I first worked on sending it all in one request, but parsing that on the server became challenging and too error-prone without a brand new model. If I were to go back and do this all again I'd change our schema for the recovery questions, but not enough time left for that.