### PR TITLE
Add date of user creation (and signature) to account page

### DIFF
--- a/erp-client/src/app/components/my-page/my-page.component.html
+++ b/erp-client/src/app/components/my-page/my-page.component.html
@@ -47,7 +47,14 @@
         <mat-error *ngIf="accountForm.controls.email.hasError('required')">Email is required</mat-error>
         <mat-error *ngIf="accountForm.controls.email.hasError('email')">Invalid email</mat-error>
       </mat-form-field>
-      <img mat-card-image>
+      <div *ngIf="meWithTimestamp || signatureData" class="meta-wrapper">
+        <mat-form-field class="created">
+          <input matInput type="text" placeholder="Date created" value="{{meWithTimestamp.timestamp.split('T')[0]}}" [readonly]="readOnly" disabled>
+        </mat-form-field>
+        <div class="img-container">
+          <img *ngIf="signatureData" [src]="signatureData" alt="Signature">
+        </div>
+      </div>
       <mat-card-actions>
         <button *ngIf="readOnly" mat-flat-button color="primary" type="button" (click)="toggleReadOnly()">Make Changes</button>
         <button *ngIf="!readOnly" [disabled]="accountForm.invalid" mat-flat-button color="primary" type="submit">Save</button>

--- a/erp-client/src/app/components/my-page/my-page.component.scss
+++ b/erp-client/src/app/components/my-page/my-page.component.scss
@@ -3,12 +3,13 @@
 mat-toolbar.mat-toolbar {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 10%;
+  margin-bottom: 5%;
 }
 
 mat-card {
   margin: auto;
   width: 50%;
+  margin-bottom: 5%;
 
   mat-card-content {
     margin-top: 5%;
@@ -38,3 +39,26 @@ h1, p {
 p {
   margin-bottom: 10%;
 }
+
+.meta-wrapper {
+  display: flex;
+  justify-content: space-between;
+
+  mat-form-field.created {
+    width: 40% !important;
+    margin-right: 10%;
+  }
+
+  .img-container {
+    display: inline-block;
+    width: 50%;
+
+    img {
+      display: block;
+      width: 100%;
+      height: auto;
+      border: gray dashed 0.5px;
+    }
+  }
+}
+

--- a/erp-client/src/app/models/user.model.ts
+++ b/erp-client/src/app/models/user.model.ts
@@ -10,6 +10,11 @@ export class User {
   isEnabled: boolean;
 }
 
+export class UserWithTimeStamp extends User {
+  timestamp: String;
+}
+
+
 export class UserWithRecoveryQuestions extends User {
   questions: RecoveryQuestion[]
 }

--- a/erp-client/src/app/services/canvas/canvas.service.ts
+++ b/erp-client/src/app/services/canvas/canvas.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
+@Injectable({providedIn: 'root'})
 export class CanvasService {
 
   private jsonHeaders: HttpHeaders = null;
@@ -16,7 +17,7 @@ export class CanvasService {
   }
 
   getSignature(): Observable<string> {
-    return this.httpClient.get('/api/signatures', {responseType: 'text'});
+    return this.httpClient.get('/api/signatures/mine', {responseType: 'text'});
   }
 
 }

--- a/erp-client/src/app/services/user/user.service.ts
+++ b/erp-client/src/app/services/user/user.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Observable} from 'rxjs';
-import {User} from '../../models/user.model';
+import {User, UserWithTimeStamp} from '../../models/user.model';
 
 @Injectable({
   providedIn: 'root'
@@ -16,12 +16,13 @@ export class UserService {
     this.jsonHeaders = new HttpHeaders({'Content-Type': 'application/json'});
   }
 
-  // getUserByUsername(username: string): Observable<User> {
-  //   return this.httpClient.get<User>(`${this.baseEndpoint}/${username}`);
-  // }
 	getUserByUsername(username: string): Observable<User> {
 		return this.httpClient.get<User>(`${this.baseEndpoint}/username/${username}`);
-	}
+  }
+  
+  getUserDetailsByUsername(username: string): Observable<UserWithTimeStamp> {
+    return this.httpClient.get<UserWithTimeStamp>(`${this.baseEndpoint}/username/${username}/details`);
+  }
 
   checkUsername(username: string): Observable<boolean> {
     return this.httpClient.get<boolean>(`${this.baseEndpoint}/validate/${username}`);

--- a/erp-server/src/main/java/com/ttt/erp/controller/SignatureController.java
+++ b/erp-server/src/main/java/com/ttt/erp/controller/SignatureController.java
@@ -35,10 +35,13 @@ public class SignatureController {
         return service.getSignatureForUsername(principal.getName());
     }
 
-    @GetMapping("/file")
-    public void findSignatureFileData(@CookieValue(value = "user") String actingUser) {
-        String fName = this.userRepo.findByUsername(actingUser).getSignature();
-        System.out.println(this.service.getSignatureBase64(fName));
+    @GetMapping("/mine")
+    public Optional<String> findSignatureFileData(@CookieValue(value = "user") String actingUser) {
+        if (this.userRepo.findByUsername(actingUser).getIsAdmin() == false) {
+            return Optional.ofNullable( this.service.getSignatureBase64(this.userRepo.findByUsername(actingUser).getSignature()) );
+        } else {
+            return Optional.empty();
+        }
     }
 
     @PostMapping

--- a/erp-server/src/main/java/com/ttt/erp/controller/UserAccountController.java
+++ b/erp-server/src/main/java/com/ttt/erp/controller/UserAccountController.java
@@ -105,6 +105,13 @@ public class UserAccountController {
         return repository.findAll();
     }
 
+
+    @GetMapping("/username/{username}/details")
+    public ResponseEntity<Object> getUserAccountDetails(@PathVariable("username") final String username) {
+        Object user = repository.getUserWithCreatedTime(username);
+        return ResponseEntity.ok().body(user);
+    }
+
     @GetMapping("/username/{username}")
     public UserAccount getUserAccount(@PathVariable("username") final String username) {
         return repository.findByUsername(username);

--- a/erp-server/src/main/java/com/ttt/erp/repository/UserAccountRepository.java
+++ b/erp-server/src/main/java/com/ttt/erp/repository/UserAccountRepository.java
@@ -12,6 +12,13 @@ public interface UserAccountRepository extends JpaRepository<UserAccount, Intege
     UserAccount findById(Long id);
     UserAccount findByUsername(String username);
 
+    // Get the User with their time of creation
+    @Query( value = "SELECT ua.*, l.modified_at\n" +
+        "FROM user_account AS ua\n" + 
+        "INNER JOIN log AS l ON l.subject_id = ua.id\n" +
+        "WHERE ua.username = :username\n" +
+        "AND l.operation  = 'insert';", nativeQuery = true)
+    Object getUserWithCreatedTime(String username);
 
     // List all users along with the number of awards given by each user
     @Query(value = "SELECT u.id, u.username, COUNT(a.id) AS total\n" +

--- a/erp-server/src/main/java/com/ttt/erp/service/UserAccountService.java
+++ b/erp-server/src/main/java/com/ttt/erp/service/UserAccountService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -51,7 +52,7 @@ public class UserAccountService extends LogService {
             UserAccount newUser = repository.save(user);
             if (!newUser.getIsAdmin()) {
                 // works for creating a new user as an unlogged in user
-                logInsert(newUser.getId(), newUser.getClass().getSimpleName(), userAccountId);
+                logInsert(userAccountId, newUser.getClass().getSimpleName(), newUser.getId());
             } else {
                 logInsert(userAccountId, newUser.getClass().getSimpleName(), newUser.getId());
             }


### PR DESCRIPTION
Add date of user creation (and signature) to account page   
  - Fix a bug someone introduced into the user create function logging   
  - Create a new endpoint and repo call for created dates with users   
  - Show the new info in the form in a half-decent way